### PR TITLE
Fix health probe paths to /api/v1/health

### DIFF
--- a/k8s/agent.yaml
+++ b/k8s/agent.yaml
@@ -46,14 +46,14 @@ spec:
               mountPath: /app/chroma_db
           readinessProbe:
             httpGet:
-              path: /health
+              path: /api/v1/health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /api/v1/health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/k8s/bot.yaml
+++ b/k8s/bot.yaml
@@ -25,7 +25,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -fsS http://agent.silvercord.svc.cluster.local:5000/health; do
+              until curl -fsS http://agent.silvercord.svc.cluster.local:5000/api/v1/health; do
                 echo "waiting for agent..."
                 sleep 3
               done

--- a/silvercord_agent/Dockerfile
+++ b/silvercord_agent/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 EXPOSE 5000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:5000/health')" || exit 1
+    CMD python -c "import requests; requests.get('http://localhost:5000/api/v1/health')" || exit 1
 
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "60", "app:app"]
 


### PR DESCRIPTION
## Summary

- The agent registers its Flask blueprint with `url_prefix='/api/v1'`, so `/health` returns 404 — the actual route is `/api/v1/health`.
- Updates k8s readiness/liveness probes (`agent.yaml`), the bot's `wait-for-agent` init container curl URL (`bot.yaml`), and the agent's Dockerfile `HEALTHCHECK` to hit the correct path.

## Why

Without this, the agent enters a liveness-restart loop (kubelet gets 404 from `/health`, treats it as failed) and the bot's init container never exits. Verified live in-cluster: `curl localhost:5000/health` returns 404, `curl localhost:5000/api/v1/health` returns 200 with status healthy.

## Test plan

- [ ] CI builds + pushes new agent image
- [ ] Agent pod becomes Ready (no more restarts)
- [ ] Bot init container exits successfully and bot pod becomes Ready
- [ ] Bot connects to Discord (visible in bot logs)